### PR TITLE
Update FlameScans.lua

### DIFF
--- a/scrapers/FlameScans.lua
+++ b/scrapers/FlameScans.lua
@@ -1,6 +1,6 @@
 --------------------------------------
 -- @name    FlameScans
--- @url     https://www.flamescans.com
+-- @url     https://www.flamescans.org
 -- @author  metafates & belphemur
 -- @license MIT
 --------------------------------------


### PR DESCRIPTION
Replace .com with .org, as the .com domain has been hijacked by scam, adware, redirects etc.